### PR TITLE
Fix: "Paths Object" sometimes has "parameters".

### DIFF
--- a/src/OpenApiValidator.ts
+++ b/src/OpenApiValidator.ts
@@ -273,7 +273,16 @@ export default class OpenApiValidator {
     path: string
   ): OperationObject {
     if (_.has(this._document, ["paths", path, method])) {
-      return this._document.paths[path][method] as OperationObject;
+      const operationObject: any = {...this._document.paths[path][method]};
+      const pathParameters = this._document.paths[path].parameters;
+      if (Array.isArray(pathParameters)) {
+        if (!Array.isArray(operationObject.parameters)) {
+          operationObject.parameters = [];
+        }
+        operationObject.parameters = 
+          operationObject.parameters.concat(pathParameters);
+      }
+      return operationObject as OperationObject;
     }
     throw new Error(
       `Path=${path} with method=${method} not found from OpenAPI document`

--- a/test/OpenApiValidator.test.ts
+++ b/test/OpenApiValidator.test.ts
@@ -202,6 +202,24 @@ describe("OpenApiValidator", () => {
     expect(err).toMatchSnapshot();
   });
 
+  test("validating path parameters with a parameters schema in paths object", async () => {
+    const validate = getValidator("get", "/parameters/all-operations-id/{pid}");
+    const err = await validate({ params: { pid: "abc" } });
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err).toMatchSnapshot();
+  });
+
+  test("validating path parameters with a parameters schema in both", async () => {
+    const validate = getValidator("get", "/parameters/both-all-operations-id/{pid}/{id}");
+    let err = await validate({ params: { pid: "123" } });
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err).toMatchSnapshot();
+    
+    err = await validate({ params: { id: "123" } });
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err).toMatchSnapshot();
+  });
+
   test("validating bodies with null fields and nullable property is schema", async () => {
     const validate = getValidator("post", "/nullable");
     let err = await validate({ body: { bar: null } });

--- a/test/__snapshots__/OpenApiValidator.test.ts.snap
+++ b/test/__snapshots__/OpenApiValidator.test.ts.snap
@@ -50,6 +50,12 @@ exports[`OpenApiValidator validating path parameters with a parameters schema 1`
 
 exports[`OpenApiValidator validating path parameters with a parameters schema 2`] = `[ValidationError: Error while validating request: request.params.id should match pattern "^[0-9]+$"]`;
 
+exports[`OpenApiValidator validating path parameters with a parameters schema in both 1`] = `[ValidationError: Error while validating request: request.params should have required property 'id']`;
+
+exports[`OpenApiValidator validating path parameters with a parameters schema in both 2`] = `[ValidationError: Error while validating request: request.params should have required property 'pid']`;
+
+exports[`OpenApiValidator validating path parameters with a parameters schema in paths object 1`] = `[ValidationError: Error while validating request: request.params.pid should match pattern "^[0-9]+$"]`;
+
 exports[`OpenApiValidator validating query parameters with internal references 1`] = `[ValidationError: Error while validating request: request.query.hello should NOT be shorter than 1 characters]`;
 
 exports[`OpenApiValidator validating query with a parameter schema 1`] = `[ValidationError: Error while validating request: request.query should have required property 'param']`;

--- a/test/openapi.yaml
+++ b/test/openapi.yaml
@@ -187,6 +187,37 @@ paths:
       responses:
         '200':
           description: Response
+  /parameters/all-operations-id/{pid}:
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+          pattern: "^[0-9]+$"
+    get:
+      responses:
+        '200':
+          description: Response
+  /parameters/both-all-operations-id/{pid}/{id}:
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+          pattern: "^[0-9]+$"
+    get:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^[0-9]+$"
+      responses:
+        '200':
+          description: Response
   /nullable:
     post:
       requestBody:


### PR DESCRIPTION
This resolves:
```
/hoge/{id}:
  # <sometimes parameters here.>
  parameters:
  - $ref: '#/components/parameters/id'
  get:
    responses:
      '200':
        description: Response
```
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md  
Thanks.