### PR TITLE
match() throws an error if no matching validator is found. Fixes #64.

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,18 +228,18 @@ Object][openapi-path-item-object]:
 `RequestHandler` is an express middleware function with the signature
 `(req: Request, res: Response, next: NextFunction): any;`.
 
-#### `match(): RequestHandler`
+#### `match(options: MatchOptions = { allowNoMatch: false }): RequestHandler`
 
 Returns an express middleware function which calls `validate()` based on the
 request method and path. Using this function removes the need to specify
 `validate()` middleware for each express endpoint individually.
 
-Note that behaviour is different to `validate()` for routes where no schema is
-specified: `validate()` will throw an exception if no matching route
-specification is found in the OpenAPI schema. `match()` will not throw an
-exception in this case; the request is simply not validated. Be careful to
-ensure you OpenAPI schema contains validators for each endpoint if using
-`match()`.
+`match()` throws an error if matching route specification is not found. This
+ensures all requests are validated.
+
+Use `match({ allowNoMatch: true})` if you want to skip validation for routes
+that are not mentioned in the OpenAPI schema. Use with caution: It allows
+requests to be handled without any validation.
 
 The following examples achieve the same result:
 

--- a/test/integration/__snapshots__/integration.test.ts.snap
+++ b/test/integration/__snapshots__/integration.test.ts.snap
@@ -139,3 +139,23 @@ Object {
   },
 }
 `;
+
+exports[`Integration tests with real app requests against /match are validated correctly 2`] = `
+Object {
+  "error": Object {
+    "data": Array [
+      Object {
+        "dataPath": ".body",
+        "keyword": "required",
+        "message": "should have required property 'input'",
+        "params": Object {
+          "missingProperty": "input",
+        },
+        "schemaPath": "#/properties/body/required",
+      },
+    ],
+    "message": "Error while validating request: request.body should have required property 'input'",
+    "name": "ValidationError",
+  },
+}
+`;

--- a/test/integration/__snapshots__/integration.test.ts.snap
+++ b/test/integration/__snapshots__/integration.test.ts.snap
@@ -159,3 +159,12 @@ Object {
   },
 }
 `;
+
+exports[`Integration tests with real app requests against /no-match cause an error 1`] = `
+Object {
+  "error": Object {
+    "message": "Path=/no-match with method=post not found from OpenAPI document",
+    "name": "Error",
+  },
+}
+`;

--- a/test/integration/app.ts
+++ b/test/integration/app.ts
@@ -16,7 +16,7 @@
 
 import cookieParser from "cookie-parser";
 import express from "express";
-import { OpenApiValidator } from "../../dist"; // eslint-disable-line
+import { OpenApiValidator, ValidationError } from "../../dist"; // eslint-disable-line
 import openApiDocument from "../open-api-document";
 
 const app: express.Express = express();
@@ -34,9 +34,7 @@ app.post("/match/:optional?", validator.match(), (req, res, _next) => {
   res.json({ output: req.params.optional || req.body.input });
 });
 
-app.post("/no-match", validator.match(), (req, res, _next) => {
-  res.json({ extra: req.body.anything });
-});
+app.post("/no-match", validator.match());
 
 app.get(
   "/parameters",
@@ -74,7 +72,7 @@ app.get(
 );
 
 const errorHandler: express.ErrorRequestHandler = (err, req, res, _next) => {
-  res.status(err.statusCode).json({
+  res.status(err instanceof ValidationError ? err.statusCode : 500).json({
     error: {
       name: err.name,
       message: err.message,

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -66,6 +66,14 @@ describe("Integration tests with real app", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ output: "works-with-url-param" });
     expect(validate(res)).toBeUndefined();
+
+    res = await request(app)
+      .post("/match/works-with-url-param")
+      .send({});
+    expect(validate(res)).toBeUndefined();
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+    expect(res.body).toMatchSnapshot();
   });
 
   test("requests against /no-match are not validated", async () => {

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -76,12 +76,13 @@ describe("Integration tests with real app", () => {
     expect(res.body).toMatchSnapshot();
   });
 
-  test("requests against /no-match are not validated", async () => {
+  test("requests against /no-match cause an error", async () => {
     const res = await request(app)
       .post("/no-match")
       .send({ anything: "anything" });
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ extra: "anything" });
+    expect(res.status).toBe(500);
+    expect(res.body).toHaveProperty("error");
+    expect(res.body).toMatchSnapshot();
   });
 
   test("path parameters are validated", async () => {

--- a/test/openapi.yaml
+++ b/test/openapi.yaml
@@ -144,6 +144,40 @@ paths:
                   - output
         default:
           $ref: "#/components/responses/Error"
+  /match/{optional}:
+    post:
+      description: Echo url-param back
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                input:
+                  type: string
+              required:
+                - input
+      parameters:
+        - name: optional
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  output:
+                    type: string
+                required:
+                  - output
+        default:
+          $ref: "#/components/responses/Error"
+
   /internal-ref:
     post:
       responses:


### PR DESCRIPTION
Hello 👋

Here is a breaking change to `match()`. I've implemented it as discussed in #64 and #63. Now `match()` will throw an error when no matching routes are found from OpenAPI schema. The error is an instance of `ValidationError` without the `.data` array.

To skip the error you can invoke `match({ allowNoMatch: true })`.

There was also a bug in the original tests for `match`. There was no matching path for `/match/works-with-url-param` in the OpenAPI schema. Thus `match()` did not invoke any validators and the test yielded a false negative. This was fixed by the first commit in this pull request.

Would this be ok to be published as `0.6.0`? Feel free to edit anything as you wish. I'll be happy to help with this one further. Let me know if e.g. changes to `ValidationError` are not welcome.