### PR TITLE
Improve SchemaObject interface by allowing ReferenceObject in some properties

### DIFF
--- a/src/OpenApiDocument.ts
+++ b/src/OpenApiDocument.ts
@@ -36,15 +36,15 @@ export interface InfoObject {
 
 export interface SchemaObject {
   type?: string;
-  items?: SchemaObject;
-  properties?: { [property: string]: SchemaObject };
+  items?: SchemaObject | ReferenceObject;
+  properties?: { [property: string]: SchemaObject | ReferenceObject };
   nullable?: boolean;
   required?: string[];
-  allOf?: SchemaObject[];
-  anyOf?: SchemaObject[];
-  oneOf?: SchemaObject[];
-  not?: SchemaObject;
-  additionalProperties?: boolean | SchemaObject;
+  allOf?: (SchemaObject | ReferenceObject)[];
+  anyOf?: (SchemaObject | ReferenceObject)[];
+  oneOf?: (SchemaObject | ReferenceObject)[];
+  not?: SchemaObject | ReferenceObject;
+  additionalProperties?: boolean | SchemaObject | ReferenceObject;
 }
 
 export interface ComponentsObject {

--- a/src/schema-utils.ts
+++ b/src/schema-utils.ts
@@ -41,8 +41,8 @@ export const resolveReference = <T>(
   return object;
 };
 
-const arrayFields = ["allOf", "anyOf", "oneOf"];
-const schemaFields = ["items", "not", "additionalProperties"];
+const arrayFields = ["allOf", "anyOf", "oneOf"] as const;
+const schemaFields = ["items", "not", "additionalProperties"] as const;
 
 export const walkSchema = (
   originalSchema: SchemaObject | ReferenceObject,
@@ -59,17 +59,21 @@ export const walkSchema = (
   arrayFields
     .filter((f) => f in schema)
     .forEach((f) => {
-      schema = { ...schema, [f]: (schema as any)[f].map(walk) };
+      schema = { ...schema, [f]: schema[f]?.map(walk) };
     });
 
   schemaFields
     .filter((f) => f in schema)
     .forEach((f) => {
-      const nestedSchema = (schema as any)[f];
+      const nestedSchema = schema[f];
       if (f === "additionalProperties" && typeof nestedSchema === "boolean") {
         return;
+      } else {
+        schema = {
+          ...schema,
+          [f]: walk(nestedSchema as SchemaObject | ReferenceObject),
+        };
       }
-      schema = { ...schema, [f]: walk(nestedSchema) };
     });
 
   return schema;

--- a/src/schema-utils.ts
+++ b/src/schema-utils.ts
@@ -45,11 +45,12 @@ const arrayFields = ["allOf", "anyOf", "oneOf"];
 const schemaFields = ["items", "not", "additionalProperties"];
 
 export const walkSchema = (
-  originalSchema: SchemaObject,
-  mapper: (x: SchemaObject) => SchemaObject,
+  originalSchema: SchemaObject | ReferenceObject,
+  mapper: (x: SchemaObject | ReferenceObject) => SchemaObject,
 ): SchemaObject => {
   let schema = mapper(originalSchema);
-  const walk = (s: SchemaObject): SchemaObject => walkSchema(s, mapper);
+  const walk = (s: SchemaObject | ReferenceObject): SchemaObject =>
+    walkSchema(s, mapper);
 
   if (schema.properties !== undefined) {
     schema = { ...schema, properties: _.mapValues(schema.properties, walk) };
@@ -75,10 +76,12 @@ export const walkSchema = (
 };
 
 export const mapOasSchemaToJsonSchema = (
-  originalSchema: SchemaObject,
+  originalSchema: SchemaObject | ReferenceObject,
   document: OpenApiDocument,
 ): SchemaObject => {
-  const mapOasFieldsToJsonSchemaFields = (s: SchemaObject): SchemaObject => {
+  const mapOasFieldsToJsonSchemaFields = (
+    s: SchemaObject | ReferenceObject,
+  ): SchemaObject => {
     const schema = resolveReference(document, s);
     if (Array.isArray(schema.type)) {
       throw new TypeError("Type field in schema must not be an array");


### PR DESCRIPTION
Improved SchemaObject interface. Many of its properties can be of type ReferenceObject per OpenAPI specification.

# Issue
Currently OpenAPI document that makes use of `$ref` in SchemaObjects do not pass TypeScript type checking because SchemaObject does not allow ReferenceObjects although the OpenAPI specification allows them. The following valid use cases of ReferenceObject do not pass type checking.

```ts
import {
  SchemaObject,
} from 'express-openapi-validate/dist/OpenApiDocument'

const refInOneOf: SchemaObject = {
  oneOf: [
    {
      $ref: '#/components/schemas/FooBar'
    }
  ]
}

const refInNot: SchemaObject = {
  not: {
    $ref: '#/components/schemas/FooBar'
  }
}

const refInItems: SchemaObject = {
  type: 'array',
  items: {
    $ref: '#/components/schemas/FooBar'
  }
}

const refInAdditionalProperties: SchemaObject = {
  additionalProperties: {
    $ref: '#/components/schemas/FooBar'
  }
}

const refInProperty: SchemaObject = {
  type: 'object',
  properties: {
    fooBar: {
      $ref: '#/components/schemas/FooBar'
    }
  }
}
```

# Argument for the changes in this PR
The use cases demonstrated above should be valid according to OpenAPI specification at https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-object and should thus pass type checking.

> allOf - Inline or **referenced** schema MUST be of a Schema Object and not a standard JSON Schema.
oneOf - Inline or **referenced** schema MUST be of a Schema Object and not a standard JSON Schema.
anyOf - Inline or **referenced** schema MUST be of a Schema Object and not a standard JSON Schema.
not - Inline or **referenced** schema MUST be of a Schema Object and not a standard JSON Schema.
items - Value MUST be an object and not an array. Inline or **referenced** schema MUST be of a Schema Object and not a standard JSON Schema. items MUST be present if the type is array.
properties - Property definitions MUST be a Schema Object and not a standard JSON Schema (inline or referenced).
additionalProperties - Value can be boolean or object. Inline or **referenced** schema MUST be of a Schema Object and not a standard JSON Schema. Consistent with JSON Schema, additionalProperties defaults to true.

Explanation on the part of `properties` leaves open the question whether individual properties can be ReferenceObjects. But I think they can because there is an example of such usage in the same specification document https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#simple-model.

```json
{
  "type": "object",
  "required": [
    "name"
  ],
  "properties": {
    "name": {
      "type": "string"
    },
    "address": {
      "$ref": "#/components/schemas/Address"
    },
    "age": {
      "type": "integer",
      "format": "int32",
      "minimum": 0
    }
  }
}
```